### PR TITLE
AENV-494 - remove endpoint field from embedly tab in snippets

### DIFF
--- a/app/views/pane-embed.html
+++ b/app/views/pane-embed.html
@@ -41,11 +41,13 @@
 
       <div class="input-name"
            ng-repeat-start="field in (newSnippet ? newSnippet.template.fields : [])"
+           ng-if="field.name != 'Endpoint'"
            >{{field.name}}<span ng-if="field.required">*</span>
             ({{field.type}})
       </div>
       <div class="template-field"
-           ng-switch="field.type" ng-repeat-end>
+           ng-switch="field.type" ng-repeat-end
+           ng-if="field.name != 'Endpoint'">
         <textarea ng-switch-when="textarea"
                   name="{{field.name}}"
                   placeholder="{{field.default}}"


### PR DESCRIPTION
Filtered out the `Endpoint` field from the view to not break the core
